### PR TITLE
Implemented nanstat and atleast<n>d functions

### DIFF
--- a/nums/core/array/blockarray.py
+++ b/nums/core/array/blockarray.py
@@ -125,12 +125,17 @@ class BlockArray(BlockArrayBase):
         self.system.get(oids)
         return self
 
-    def reshape(self, shape=None, **kwargs):
+    def reshape(self, *shape, **kwargs):
         block_shape = kwargs.get("block_shape", None)
         if array_utils.is_int(shape):
             shape = (shape,)
-        elif shape is None:
+        elif len(shape) == 0:
             shape = self.shape
+        elif isinstance(shape[0], (tuple, list)):
+            assert len(shape) == 1
+            shape = shape[0]
+        else:
+            assert all(np.issubdtype(type(n), int) for n in shape)
         shape = Reshape.compute_shape(self.shape, shape)
         if block_shape is None:
             if shape == self.shape:

--- a/nums/core/cmds/api_coverage.py
+++ b/nums/core/cmds/api_coverage.py
@@ -148,8 +148,8 @@ def api_coverage(print_missing, count_fallback):
         # Rest
         'angle', 'append', 'apply_along_axis', 'apply_over_axes',
         'argpartition', 'argsort', 'argwhere', 'around',
-        'array_split', 'asarray', 'asarray_chkfinite', 'asscalar', 'atleast_1d',
-        'atleast_2d', 'atleast_3d', 'average',
+        'array_split', 'asarray', 'asarray_chkfinite', 'asscalar',
+        'average',
         'bartlett', 'bincount', 'blackman',
         'choose', 'clip', 'column_stack', 'common_type', 'compress', 'convolve', 'corrcoef',
         'correlate', 'count_nonzero', 'cov', 'cross', 'cumprod', 'cumproduct', 'cumsum',
@@ -170,7 +170,6 @@ def api_coverage(print_missing, count_fallback):
         'median', 'meshgrid', 'min_scalar_type', 'mintypecode', 'mirr', 'modf', 'moveaxis', 'msort',
         'nan_to_num', 'nanargmax', 'nanargmin', 'nancumprod', 'nancumsum',
         'nanmedian', 'nanpercentile', 'nanprod', 'nanquantile',
-        'nanstd', 'nanvar',
         'nonzero', 'nper', 'npv',
         'obj2sctype',
         'packbits', 'pad', 'partition', 'percentile', 'piecewise', 'place',

--- a/nums/models/glms.py
+++ b/nums/models/glms.py
@@ -235,7 +235,7 @@ class LogisticRegression(GLM):
         if mu is None:
             mu = self.forward(X)
         dim, block_dim = mu.shape[0], mu.block_shape[0]
-        s = (mu * (self._app.one - mu)).reshape(shape=(dim, 1), block_shape=(block_dim, 1))
+        s = (mu * (self._app.one - mu)).reshape((dim, 1), block_shape=(block_dim, 1))
         if self._penalty is None:
             return X.T @ (s * X)
         else:
@@ -248,7 +248,7 @@ class LogisticRegression(GLM):
         return (self.forward(X) > 0.5).astype(np.int)
 
     def predict_proba(self, X: BlockArray) -> BlockArray:
-        y_pos = self.forward(X).reshape(shape=(X.shape[0], 1), block_shape=(X.block_shape[0], 1))
+        y_pos = self.forward(X).reshape((X.shape[0], 1), block_shape=(X.block_shape[0], 1))
         y_neg = 1 - y_pos
         return self._app.concatenate([y_pos, y_neg], axis=1, axis_block_size=2)
 

--- a/nums/numpy/api.py
+++ b/nums/numpy/api.py
@@ -229,6 +229,17 @@ def diag(v: BlockArray, k=0) -> BlockArray:
     return app.diag(v)
 
 
+def atleast_1d(*arys):
+    return _instance().atleast_1d(*arys)
+
+
+def atleast_2d(*arys):
+    return _instance().atleast_2d(*arys)
+
+
+def atleast_3d(*arys):
+    return _instance().atleast_3d(*arys)
+
 ############################################
 # Manipulation Ops
 ############################################
@@ -432,6 +443,7 @@ def any(a: BlockArray, axis=None, out=None, keepdims=False):
         raise NotImplementedError("'out' is currently not supported.")
     return _instance().reduce("any", a, axis=axis, keepdims=keepdims)
 
+
 ############################################
 # NaN Ops
 ############################################
@@ -460,6 +472,17 @@ def nanmean(a: BlockArray, axis=None, dtype=None, out=None, keepdims=False):
         raise NotImplementedError("'out' is currently not supported.")
     return _instance().nanmean(a, axis=axis, dtype=dtype, keepdims=keepdims)
 
+
+def nanvar(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
+    if out is not None:
+        raise NotImplementedError("'out' is currently not supported.")
+    return _instance().nanvar(a, axis=axis, dtype=dtype, ddof=ddof, keepdims=keepdims)
+
+
+def nanstd(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
+    if out is not None:
+        raise NotImplementedError("'out' is currently not supported.")
+    return _instance().nanstd(a, axis=axis, dtype=dtype, ddof=ddof, keepdims=keepdims)
 
 ############################################
 # Utility Ops

--- a/tests/core/array/test_basic.py
+++ b/tests/core/array/test_basic.py
@@ -43,7 +43,7 @@ def test_transpose(app_inst: ArrayApplication):
 def test_reshape(app_inst: ArrayApplication):
     real_X, _ = BimodalGaussian.get_dataset(1000, 9)
     X = app_inst.array(real_X, block_shape=(100, 9))
-    X = X.reshape(shape=(1000, 9), block_shape=(1000, 1))
+    X = X.reshape((1000, 9), block_shape=(1000, 1))
     assert np.allclose(X.get(), real_X)
 
 

--- a/tests/core/array/test_reshape.py
+++ b/tests/core/array/test_reshape.py
@@ -108,9 +108,9 @@ def test_reshape_blocks_only(app_inst):
     shape, block_shape = (3, 5, 10), (3, 2, 5)
     arr = app_inst.random_state(1337).random(shape, block_shape)
     arr_np = arr.get()
-    assert np.allclose(arr_np, arr.reshape(shape=shape, block_shape=(2, 2, 5)).get())
-    assert np.allclose(arr_np, arr.reshape(shape=shape, block_shape=(2, 3, 5)).get())
-    assert np.allclose(arr_np, arr.reshape(shape=shape, block_shape=(2, 3, 7)).get())
+    assert np.allclose(arr_np, arr.reshape(shape, block_shape=(2, 2, 5)).get())
+    assert np.allclose(arr_np, arr.reshape(shape, block_shape=(2, 3, 5)).get())
+    assert np.allclose(arr_np, arr.reshape(shape, block_shape=(2, 3, 7)).get())
 
 
 if __name__ == "__main__":

--- a/tests/numpy/test_misc.py
+++ b/tests/numpy/test_misc.py
@@ -107,7 +107,7 @@ def test_reshape(nps_app_inst):
     import nums.numpy as nps
     assert nps_app_inst is not None
     ba = nps.arange(2 * 3 * 4).reshape((2, 3, 4), block_shape=(2, 3, 4))
-    assert nps.allclose(ba.reshape(shape=(6, 4), block_shape=(6, 4)),
+    assert nps.allclose(ba.reshape((6, 4), block_shape=(6, 4)),
                         nps.reshape(ba, shape=(6, 4)))
 
 
@@ -129,8 +129,8 @@ def test_all_alltrue_any(nps_app_inst):
         assert nps.all(nps_array).get() == np.all(array)
         assert nps.alltrue(nps_array).get() == np.alltrue(array)
 
-        assert nps.all(nps_array).dtype is np.bool
-        assert nps.alltrue(nps_array).dtype is np.bool
+        assert nps.all(nps_array).dtype is bool
+        assert nps.alltrue(nps_array).dtype is bool
 
     false_int = np.array([[0, 0, 0], [0, 0, 0]])
     false_bool = np.array([[False, False, False], [False, False, False]])
@@ -142,7 +142,7 @@ def test_all_alltrue_any(nps_app_inst):
         nps_array = nps.array(array).reshape(block_shape=(2, 2))
         assert nps.any(nps_array).get() == np.any(array)
 
-        assert nps.any(nps_array).dtype is np.bool
+        assert nps.any(nps_array).dtype is bool
 
 
 def test_array_eq(nps_app_inst):
@@ -170,9 +170,9 @@ def test_array_eq(nps_app_inst):
         assert nps.allclose(nps_array_1, nps_array_1).get() == np.allclose(check[0], check[0])
         assert nps.allclose(nps_array_1, nps_array_2).get() == np.allclose(check[0], check[1])
 
-        assert nps.array_equal(nps_array_1, nps_array_2).dtype is np.bool
-        assert nps.array_equiv(nps_array_1, nps_array_2).dtype is np.bool
-        assert nps.allclose(nps_array_1, nps_array_2).dtype is np.bool
+        assert nps.array_equal(nps_array_1, nps_array_2).dtype is bool
+        assert nps.array_equiv(nps_array_1, nps_array_2).dtype is bool
+        assert nps.allclose(nps_array_1, nps_array_2).dtype is bool
 
     # False interaction test
     checks_1 = [np.array([False]), np.array([False]),

--- a/tests/numpy/test_nan_reduction.py
+++ b/tests/numpy/test_nan_reduction.py
@@ -20,6 +20,8 @@ import numpy as np
 
 warnings.filterwarnings("ignore", "All-NaN (slice|axis) encountered")
 warnings.filterwarnings("ignore", "Mean of empty slice")
+warnings.filterwarnings("ignore", "invalid value encountered in true_divide")
+warnings.filterwarnings("ignore", "Degrees of freedom <= 0 for slice.")
 
 
 # pylint: disable=import-outside-toplevel, no-member
@@ -41,7 +43,7 @@ def test_nan_reductions(nps_app_inst):
     for block_shape in block_shapes:
         ba = ba.reshape(block_shape=block_shape)
         np_arr = ba.get()
-        op_params = ["nanmax", "nanmin", "nansum", "nanmean"]
+        op_params = ["nanmax", "nanmin", "nansum", "nanmean", "nanvar", "nanstd"]
         axis_params = [None, 0, 1]
         keepdims_params = [True, False]
 

--- a/tests/numpy/test_np_random.py
+++ b/tests/numpy/test_np_random.py
@@ -50,7 +50,7 @@ def test_shuffle(nps_app_inst):
 
     shape = (12, 34, 56)
     block_shape = (2, 5, 7)
-    arr: BlockArray = nps.arange(np.product(shape)).reshape(shape=shape, block_shape=block_shape)
+    arr: BlockArray = nps.arange(np.product(shape)).reshape(shape, block_shape=block_shape)
     np_arr = arr.get()
 
     for axis in range(3):
@@ -77,7 +77,7 @@ def test_shuffle_subscript_ops(nps_app_inst):
 
     shape = (123, 45)
     block_shape = (10, 20)
-    arr: BlockArray = nps.arange(np.product(shape)).reshape(shape=shape, block_shape=block_shape)
+    arr: BlockArray = nps.arange(np.product(shape)).reshape(shape, block_shape=block_shape)
     np_arr = arr.get()
     rs = nps.random.RandomState(1337)
     idx: BlockArray = rs.permutation(shape[1])
@@ -94,7 +94,7 @@ def test_blockarray_perm(nps_app_inst):
 
     shape = (12, 34)
     block_shape = (5, 10)
-    arr: BlockArray = nps.arange(np.product(shape)).reshape(shape=shape, block_shape=block_shape)
+    arr: BlockArray = nps.arange(np.product(shape)).reshape(shape, block_shape=block_shape)
     np_arr = arr.get()
     rs = nps.random.RandomState(1337)
     np_arr_shuffle: BlockArray = rs.permutation(arr).get()

--- a/tests/numpy/test_np_reshape.py
+++ b/tests/numpy/test_np_reshape.py
@@ -39,7 +39,7 @@ def test_reshape_noops(nps_app_inst):
     arr = nps_app_inst.random_state(1337).random(shape, block_shape)
     new_arr = arr.reshape()
     assert arr is new_arr
-    new_arr = arr.reshape(shape=shape)
+    new_arr = arr.reshape(shape)
     assert arr is new_arr
     new_arr = arr.reshape(block_shape=block_shape)
     assert arr is new_arr

--- a/tests/numpy/test_stack.py
+++ b/tests/numpy/test_stack.py
@@ -1,0 +1,101 @@
+# coding=utf-8
+# Copyright (C) 2020 NumS Development Team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import itertools
+import numpy as np
+
+# pylint: disable=import-outside-toplevel
+
+def try_multiple_nd(np_atleast_nd, nps_atleast_nd):
+    import nums.numpy as nps
+
+    python_types = [
+        1,
+        [1, 2],
+        [[1, 2]],
+        [[[1, 2]]]
+    ]
+    all_types = python_types + list(map(np.array, python_types))
+    test_cases = list(itertools.product(all_types, repeat=3))
+    nps_types = list(map(nps.array, python_types))
+    nps_cases = list(itertools.product(nps_types, repeat=3))
+
+    for arguments in test_cases:
+        np_res = np_atleast_nd(*arguments)
+        nps_res = nps_atleast_nd(*arguments)
+
+        for i in range(len(np_res)):
+            assert np.allclose(np.array(nps_res[i].get()), np.array(np_res[i]))
+
+    for arguments in nps_cases:
+        np_args = list(map(lambda obj: np.array(obj.get()), arguments))
+        np_res = np_atleast_nd(*np_args)
+        nps_res = nps_atleast_nd(*arguments)
+        for i in range(len(np_res)):
+            assert np.allclose(np.array(nps_res[i].get()), np.array(np_res[i]))
+
+
+def test_atleast_1d(nps_app_inst):
+    import nums.numpy as nps
+    assert nps_app_inst is not None
+
+    x = 1.0
+    assert np.allclose(nps.atleast_1d(x).get(), np.atleast_1d(x))
+
+    x_np = np.arange(9).reshape(3, 3)
+    x_nps = nps.arange(9).reshape(3, 3)
+    assert np.allclose(nps.atleast_1d(x_np).get(), np.atleast_1d(x_np))
+    assert np.allclose(nps.atleast_1d(x_nps).get(), np.atleast_1d(x_np))
+    assert np.atleast_1d(x_np) is x_np
+    assert nps.atleast_1d(x_nps) is x_nps
+
+    try_multiple_nd(np.atleast_1d, nps.atleast_1d)
+
+
+def test_atleast_2d(nps_app_inst):
+    import nums.numpy as nps
+    assert nps_app_inst is not None
+
+    x = 1.0
+    assert np.allclose(nps.atleast_2d(x).get(), np.atleast_2d(x))
+
+    x = np.arange(3.0)
+    assert np.allclose(nps.atleast_2d(x).get(), np.atleast_2d(x))
+
+    try_multiple_nd(np.atleast_2d, nps.atleast_2d)
+
+
+def test_atleast_3d(nps_app_inst):
+    import nums.numpy as nps
+    assert nps_app_inst is not None
+
+    x = 1.0
+    assert np.allclose(nps.atleast_1d(x).get(), np.atleast_1d(x))
+
+    x = np.arange(12.0).reshape(4, 3)
+    assert np.allclose(nps.atleast_1d(x).get(), np.atleast_1d(x))
+
+    try_multiple_nd(np.atleast_3d, nps.atleast_3d)
+
+if __name__ == "__main__":
+    # pylint: disable=import-error
+    from nums.core import application_manager
+    import nums.core.settings
+
+    nums.core.settings.system_name = "serial"
+    nps_app_inst = application_manager.instance()
+    test_atleast_1d(nps_app_inst)
+    test_atleast_2d(nps_app_inst)
+    test_atleast_3d(nps_app_inst)


### PR DESCRIPTION
- Implemented: `nanstd`, `nanvar`, `atleast_1d`, `atleast_2d`, `atleast_3d`

- Fixed: `reshape`, the `shape` parameter no longer has to be a tuple

- Updated now invalid uses of `reshape(shape=<shape>)`

- Replaced some uses of the deprecated `np.bool` with `bool`