### PR TITLE
Add NotImplementedError for matmul with tensors

### DIFF
--- a/nums/core/array/blockarray.py
+++ b/nums/core/array/blockarray.py
@@ -410,7 +410,8 @@ class BlockArray(BlockArrayBase):
 
     def __matmul__(self, other):
         if len(self.shape) > 2:
-            return self.tensordot(other, 2)
+            # TODO: (bcp) NumPy's implementation does a stacked matmul, which is not supported yet.
+            raise NotImplementedError("Matrix multiply for tensors of rank > 2 not supported yet")
         else:
             return self.tensordot(other, 1)
 

--- a/nums/core/array/blockarray.py
+++ b/nums/core/array/blockarray.py
@@ -411,7 +411,7 @@ class BlockArray(BlockArrayBase):
     def __matmul__(self, other):
         if len(self.shape) > 2:
             # TODO: (bcp) NumPy's implementation does a stacked matmul, which is not supported yet.
-            raise NotImplementedError("Matrix multiply for tensors of rank > 2 not supported yet")
+            raise NotImplementedError("Matrix multiply for tensors of rank > 2 not supported yet.")
         else:
             return self.tensordot(other, 1)
 

--- a/tests/numpy/test_arithmetic.py
+++ b/tests/numpy/test_arithmetic.py
@@ -114,7 +114,24 @@ def test_matmul_tensordot(nps_app_inst):
     np_B = np.transpose(np.stack([np_w + i for i in range(20)]))
     check_matmul_op(np_A, np_B)
 
-# TODO(bcp): Add matmul tests for rank > 2
+
+def test_matmul_tensor(nps_app_inst):
+
+    from nums import numpy as nps
+
+    import pytest
+
+    assert nps_app_inst is not None
+
+    # TODO(bcp): Replace with matmul tests for rank > 2 once implemented.
+    def check_matmul_tensor(_ns_a, _ns_b):
+        with pytest.raises(NotImplementedError):
+            nps.matmul(_ns_a, _ns_b)
+
+    ns_a = nps.array([[[0, 1], [2, 3]], [[4, 5], [6, 7]]])
+    ns_b = nps.array([[[7, 6], [5, 4]], [[3, 2], [1, 0]]])
+    check_matmul_tensor(ns_a, ns_b)
+
 
 # TODO(hme): Add broadcast tests.
 

--- a/tests/numpy/test_arithmetic.py
+++ b/tests/numpy/test_arithmetic.py
@@ -114,6 +114,7 @@ def test_matmul_tensordot(nps_app_inst):
     np_B = np.transpose(np.stack([np_w + i for i in range(20)]))
     check_matmul_op(np_A, np_B)
 
+# TODO(bcp): Add matmul tests for rank > 2
 
 # TODO(hme): Add broadcast tests.
 


### PR DESCRIPTION
Currently, there is a correctness error with matmul and tensors of rank > 2. Disabled the current implementation, and added a NotImplementedError for now.

As stated in the [NumPy docs](https://numpy.org/doc/stable/reference/generated/numpy.matmul.html), the correct behavior should be:

> If either argument is N-D, N > 2, it is treated as a stack of matrices residing in the last two indexes and broadcast accordingly.

NumS is calling tensordot instead, and a separate subroutine for matmul with tensors needs to be implemented.