### PR TITLE
Added fallback functionality

### DIFF
--- a/nums/api.py
+++ b/nums/api.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 
 
-import numpy as np
-
 from nums.core.application_manager import instance as _instance
 from nums.core.array.blockarray import BlockArray
 
@@ -68,7 +66,7 @@ def delete(filename: str) -> BlockArray:
         return _instance().delete_fs(filename)
 
 
-def read_csv(filename, dtype=np.float, delimiter=',', has_header=False) -> BlockArray:
+def read_csv(filename, dtype=float, delimiter=',', has_header=False) -> BlockArray:
     """Read a csv text file.
 
     Args:

--- a/nums/core/array/blockarray.py
+++ b/nums/core/array/blockarray.py
@@ -46,9 +46,9 @@ class BlockArray(BlockArrayBase):
     @classmethod
     def from_scalar(cls, val, system):
         if isinstance(val, int):
-            dtype = np.int
+            dtype = int
         elif isinstance(val, float):
-            dtype = np.float
+            dtype = float
         else:
             assert isinstance(val, (np.int32, np.int64, np.float32, np.float64))
             dtype = None
@@ -661,7 +661,7 @@ class BlockArray(BlockArrayBase):
             "Currently supports comparison with scalars only."
         shape = array_utils.broadcast(self.shape, other.shape).shape
         block_shape = array_utils.broadcast_block_shape(self.shape, other.shape, self.block_shape)
-        dtype = np.bool.__name__
+        dtype = bool.__name__
         grid = ArrayGrid(shape, block_shape, dtype)
         result = BlockArray(grid, self.system)
         for grid_entry in result.grid.get_entry_iterator():

--- a/nums/core/array/selection.py
+++ b/nums/core/array/selection.py
@@ -227,7 +227,7 @@ class AxisArray(AxisSelection):
             # Must infer type.
             is_bool = True
             for entry in array_like:
-                if not isinstance(entry, (np.intp, np.bool, int, bool)):
+                if not isinstance(entry, (np.intp, int, bool)):
                     raise Exception("Only integer or boolean arrays are valid indices.")
                 if isinstance(entry, (int, np.intp)):
                     is_bool = False

--- a/nums/core/array/utils.py
+++ b/nums/core/array/utils.py
@@ -49,12 +49,12 @@ def is_uint(val, type_test=False):
 
 def is_int(val, type_test=False):
     return is_type(type_test, val,
-                   (int, np.int, np.int8, np.int16, np.int32, np.int64))
+                   (int, np.int8, np.int16, np.int32, np.int64))
 
 
 def is_float(val, type_test=False):
     return is_type(type_test, val,
-                   (float, np.float, np.float16, np.float32, np.float64))
+                   (float, np.float16, np.float32, np.float64))
 
 
 def is_complex(val, type_test=False):
@@ -75,7 +75,7 @@ def get_reduce_output_type(op_name, dtype):
 def shape_from_block_array(arr: np.ndarray):
     grid_shape = arr.shape
     num_axes = len(arr.shape)
-    shape = np.zeros(num_axes, dtype=np.int)
+    shape = np.zeros(num_axes, dtype=int)
     for j in range(num_axes):
         pos = [[0]] * num_axes
         pos[j] = range(grid_shape[j])

--- a/nums/core/cmds/api_coverage.py
+++ b/nums/core/cmds/api_coverage.py
@@ -17,7 +17,7 @@
 import argparse
 
 from nums.core.systems import utils as systems_utils
-
+from nums.core import settings
 
 # pylint: disable = import-outside-toplevel
 
@@ -49,7 +49,7 @@ def module_coverage(module_name, print_missing, count_fallback,
     print("-"*75)
 
     for name, func in systems_utils.get_module_functions(nums_module).items():
-        if name in ("_not_implemented", "_instance"):
+        if name in ("_not_implemented", "_instance", "_default_to_numpy"):
             continue
         if getattr(numpy_module, name, None) is None:
             raise Exception("Implemented method that does not exist! %s" % name)
@@ -141,57 +141,10 @@ def api_coverage(print_missing, count_fallback):
         'savetxt', 'shares_memory'
     }
 
-    # Fallback on NumPy for these operations.
-    # This is achieved by converting the block array to a single block, performing the operation,
-    # and converting back to the original block shape.
-    fallback = {
-        # Rest
-        'angle', 'append', 'apply_along_axis', 'apply_over_axes',
-        'argpartition', 'argsort', 'argwhere', 'around',
-        'array_split', 'asarray', 'asarray_chkfinite', 'asscalar',
-        'average',
-        'bartlett', 'bincount', 'blackman',
-        'choose', 'clip', 'column_stack', 'common_type', 'compress', 'convolve', 'corrcoef',
-        'correlate', 'count_nonzero', 'cov', 'cross', 'cumprod', 'cumproduct', 'cumsum',
-        'delete', 'diag_indices', 'diag_indices_from', 'diagflat', 'diagonal', 'diff', 'digitize',
-        'divmod', 'dot', 'dsplit', 'dstack',
-        'ediff1d', 'einsum', 'einsum_path', 'extract',
-        'fill_diagonal', 'fix', 'flatnonzero', 'flip', 'fliplr', 'flipud', 'frexp', 'frombuffer',
-        'fromfile', 'fromfunction', 'fromiter', 'frompyfunc', 'full',
-        'full_like', 'fv',
-        'geomspace', 'gradient',
-        'hamming', 'hanning',
-        'histogram', 'histogram2d', 'histogram_bin_edges', 'histogramdd', 'hsplit', 'hstack', 'i0',
-        'imag', 'in1d', 'indices', 'insert', 'interp', 'intersect1d', 'ipmt',
-        'irr', 'isclose', 'iscomplex', 'iscomplexobj', 'isin',
-        'isneginf', 'isposinf', 'isreal', 'isrealobj', 'isscalar',
-        'ix_', 'kaiser', 'kron', 'lexsort',
-        'maximum_sctype',
-        'median', 'meshgrid', 'min_scalar_type', 'mintypecode', 'mirr', 'modf', 'moveaxis', 'msort',
-        'nan_to_num', 'nanargmax', 'nanargmin', 'nancumprod', 'nancumsum',
-        'nanmedian', 'nanpercentile', 'nanprod', 'nanquantile',
-        'nonzero', 'nper', 'npv',
-        'obj2sctype',
-        'packbits', 'pad', 'partition', 'percentile', 'piecewise', 'place',
-        'pmt', 'poly', 'polyadd', 'polyder', 'polydiv', 'polyfit', 'polyint', 'polymul', 'polysub',
-        'polyval', 'ppmt', 'prod', 'product', 'promote_types', 'ptp', 'put',
-        'put_along_axis', 'putmask', 'pv',
-        'quantile', 'rate', 'ravel', 'ravel_multi_index', 'real',
-        'real_if_close', 'repeat', 'require', 'resize',
-        'result_type', 'roll', 'rollaxis', 'roots', 'rot90', 'round', 'round_', 'row_stack',
-        'sctype2char', 'searchsorted',
-        'select', 'setdiff1d', 'setxor1d',
-        'sinc', 'sometrue', 'sort', 'sort_complex',
-        'stack', 'swapaxes', 'take', 'take_along_axis', 'tile', 'trace',
-        'trapz', 'tri', 'tril', 'tril_indices', 'tril_indices_from', 'trim_zeros', 'triu',
-        'triu_indices', 'triu_indices_from', 'union1d', 'unique', 'unpackbits',
-        'unravel_index', 'unwrap', 'vander', 'vdot', 'vsplit', 'vstack', 'who'
-    }
-
     import numpy as numpy_module
     import nums.numpy.api as nums_module
     module_coverage("api", print_missing, count_fallback,
-                    numpy_module, nums_module, ignore=ignore, fallback=fallback)
+                    numpy_module, nums_module, ignore=ignore, fallback=settings.fallback)
 
 
 def main():

--- a/nums/core/settings.py
+++ b/nums/core/settings.py
@@ -69,3 +69,43 @@ np_bop_reduction_set = {
     "nanmin",
     "nansum"
 }
+
+# Fallback on NumPy for these operations.
+# This is achieved by converting the block array to a single block, performing the operation,
+# and converting back to the original block shape.
+doctest_fallback = {
+    'argwhere', 'asscalar', 'clip', 'compress', 'convolve', 'corrcoef', 'cumprod',
+    'cumproduct', 'cumsum', 'diag_indices_from', 'diagflat', 'fix', 'fromiter', 'full',
+    'msort', 'nancumprod', 'nancumsum', 'nanprod', 'partition', 'polysub', 'product',
+    'ravel_multi_index', 'repeat', 'resize', 'roll', 'roots', 'rot90', 'round',
+    'round_', 'searchsorted', 'setdiff1d', 'setxor1d', 'sometrue', 'sort_complex', 'swapaxes',
+    'tile', 'trapz', 'tri', 'tril', 'tril_indices_from', 'triu', 'triu_indices_from', 'union1d'
+}
+
+manually_tested_fallback = {
+    'cov'
+}
+
+failed_fallback = {
+    'angle', 'append', 'apply_along_axis', 'apply_over_axes', 'argsort', 'around', 'array_split',
+    'argpartition', 'asarray', 'asarray_chkfinite', 'average', 'bartlett', 'bincount', 'blackman',
+    'choose', 'column_stack', 'common_type', 'correlate', 'count_nonzero', 'cov', 'cross', 'delete',
+    'diag_indices', 'diagonal', 'diff', 'digitize', 'divmod', 'dot', 'dsplit', 'dstack', 'ediff1d',
+    'einsum', 'einsum_path', 'extract', 'fill_diagonal', 'flatnonzero', 'flip', 'fliplr', 'flipud',
+    'frexp', 'frombuffer', 'fromfile', 'fromfunction', 'frompyfunc', 'full_like', 'geomspace',
+    'gradient', 'hamming', 'hanning', 'histogram', 'histogram2d', 'histogram_bin_edges',
+    'histogramdd', 'hsplit', 'hstack', 'i0', 'imag', 'in1d', 'indices', 'insert', 'interp',
+    'intersect1d', 'isclose', 'iscomplex', 'iscomplexobj', 'isin', 'isneginf',
+    'isposinf', 'isreal', 'isrealobj', 'isscalar', 'ix_', 'kaiser', 'kron', 'lexsort',
+    'maximum_sctype', 'median', 'meshgrid', 'min_scalar_type', 'mintypecode', 'modf', 'moveaxis',
+    'nan_to_num', 'nanargmax', 'nanargmin', 'nanmedian', 'nanpercentile', 'nanquantile', 'nonzero',
+    'obj2sctype', 'packbits', 'pad', 'percentile', 'piecewise', 'place', 'poly',
+    'polyadd', 'polyder', 'polydiv', 'polyfit', 'polyint', 'polymul', 'polyval', 'prod',
+    'promote_types', 'ptp', 'put', 'put_along_axis', 'putmask', 'quantile', 'ravel', 'real',
+    'real_if_close', 'require', 'result_type', 'rollaxis', 'row_stack', 'sctype2char', 'select',
+    'sinc', 'sort', 'stack', 'take', 'take_along_axis', 'trace', 'tril_indices', 'trim_zeros',
+    'triu_indices', 'unique', 'unpackbits', 'unravel_index', 'unwrap', 'vander', 'vdot', 'vsplit',
+    'vstack', 'who'
+}
+
+fallback = doctest_fallback | manually_tested_fallback | failed_fallback

--- a/nums/core/systems/filesystem.py
+++ b/nums/core/systems/filesystem.py
@@ -399,7 +399,7 @@ class FileSystem(object):
             )
         return result
 
-    def read_csv(self, filename, dtype=np.float, delimiter=',', has_header=False, num_workers=4):
+    def read_csv(self, filename, dtype=float, delimiter=',', has_header=False, num_workers=4):
         file_size = storage_utils.get_file_size(filename)
         file_batches: storage_utils.Batch = storage_utils.Batch.from_num_batches(file_size,
                                                                                  num_workers)

--- a/nums/core/systems/schedulers.py
+++ b/nums/core/systems/schedulers.py
@@ -150,7 +150,7 @@ class BlockCyclicScheduler(TaskScheduler):
         super(BlockCyclicScheduler, self).__init__(compute_module, use_head)
         self.verbose = verbose
         self.cluster_shape: Tuple = cluster_shape
-        self.cluster_grid: np.ndarray = np.empty(shape=self.cluster_shape, dtype=np.object)
+        self.cluster_grid: np.ndarray = np.empty(shape=self.cluster_shape, dtype=object)
 
     def init(self):
         super().init()

--- a/nums/numpy/__init__.py
+++ b/nums/numpy/__init__.py
@@ -16,12 +16,12 @@
 
 # pylint: disable = redefined-builtin
 
-
-from nums.core.array.blockarray import BlockArray
 from nums.numpy import random
 from nums.numpy import linalg
 from nums.numpy.api import _not_implemented
+from nums.numpy.api import _default_to_numpy
 from nums.numpy.api import *
+from nums.core import settings
 
 
 # TODO(hme): Generate __all__, or control import hints some other way.
@@ -31,9 +31,17 @@ def _init():
     # pylint: disable=import-outside-toplevel
     import numpy as np
     from nums.core.systems import utils as system_utils
+
     for name, func in system_utils.get_module_functions(np).items():
         if name not in globals():
-            globals()[name] = _not_implemented(func)
+            # TODO(mwe): Allow failed fallback functions to be used in default function doctests
+            if hasattr(np, func.__name__) and \
+                    func.__name__ in settings.doctest_fallback | settings.manually_tested_fallback:
+                globals()[name] = _default_to_numpy(func)
+            else:
+                globals()[name] = _not_implemented(func)
+            if hasattr(np, func.__name__):
+                globals()[name].__doc__ = np.__getattribute__(func.__name__).__doc__
 
 
 _init()

--- a/nums/numpy/numpy_utils.py
+++ b/nums/numpy/numpy_utils.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+import re
 import numpy as np
 
 from nums.core.array.application import ArrayApplication
@@ -71,3 +71,25 @@ def get_num_cores(app: ArrayApplication):
     else:
         assert isinstance(app.system, SerialSystem)
         return systems_utils.get_num_cores()
+
+
+def update_doc_string(doc_string):
+    # TODO(mwe): Continue to improve regex edge cases
+    # np -> nps
+    doc_string = re.sub('np(?![a-zA-Z_])', 'nps', str(doc_string))
+    # Remove comments
+    doc_string = re.sub('#.*', '', doc_string)
+    # Round all numbers
+    nums_funcs = list(set(re.findall(r">>>\s[\.a-zA-Z0-9, ()].*\n(?!\s*>)", doc_string)))
+    for nums_func in nums_funcs:
+        doc_string = doc_string.replace(nums_func,
+                                        ">>> eval(\"np.around(" + nums_func[4:].rstrip()
+                                        + ".get(), 5)\")\n")
+    numbers = list(set(re.findall(r"-?[0-9]\d{0,9}\.\d+", doc_string)))
+    for num in numbers:
+        doc_string = doc_string.replace(num, str(np.round(float(num), 5)))
+    # Convert array(<num>) to num: e.g. array(11) -> 11
+    ret_nums = list(set(re.findall(r"(?<=\n\s)*array\(-?[0-9]\d{0,9}\.\d+\)", doc_string)))
+    for ret_num in ret_nums:
+        doc_string = doc_string.replace(ret_num, ret_num[6:-1])
+    return doc_string

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import pytest
 import ray
 

--- a/tests/core/test_app_manager.py
+++ b/tests/core/test_app_manager.py
@@ -28,7 +28,7 @@ def test_app_manager():
             settings.compute_name = compute_name
             settings.system_name = system_name
             app: ArrayApplication = application_manager.instance()
-            assert np.allclose(np.arange(10), app.arange(shape=(10,), block_shape=(10,)).get())
+            assert np.allclose(np.arange(10), app.arange(0, shape=(10,), block_shape=(10,)).get())
             application_manager.destroy()
             assert not application_manager.is_initialized()
             time.sleep(1)

--- a/tests/numpy/test_arithmetic.py
+++ b/tests/numpy/test_arithmetic.py
@@ -58,21 +58,21 @@ def test_ufunc(nps_app_inst):
             np_b = np.array([True, True, False, False], dtype=np.bool_)
             check_bop(name, np_a, np_b)
         elif name in ("gcd", "lcm"):
-            np_a = np.array([8, 3, 7], dtype=np.int)
-            np_b = np.array([4, 12, 13], dtype=np.int)
+            np_a = np.array([8, 3, 7], dtype=int)
+            np_b = np.array([4, 12, 13], dtype=int)
             check_bop(name, np_a, np_b)
         elif name.endswith("shift"):
-            np_a = np.array([7*10**3, 8*10**3, 9*10**3], dtype=np.int)
-            np_b = np.array([1, 2, 3], dtype=np.int)
+            np_a = np.array([7*10**3, 8*10**3, 9*10**3], dtype=int)
+            np_b = np.array([1, 2, 3], dtype=int)
             check_bop(name, np_a, np_b)
         else:
             pairs = [
                 (np.array([.1, 5.0, .3]),
                  np.array([.2, 6.0, .3])),
                 (np.array([.1, 5.0, .3]),
-                 np.array([4, 2, 6], dtype=np.int)),
-                (np.array([3, 7, 3], dtype=np.int),
-                 np.array([4, 2, 6], dtype=np.int)),
+                 np.array([4, 2, 6], dtype=int)),
+                (np.array([3, 7, 3], dtype=int),
+                 np.array([4, 2, 6], dtype=int)),
             ]
             for np_a, np_b in pairs:
                 check_bop(name, np_a, np_b)

--- a/tests/numpy/test_fallback.py
+++ b/tests/numpy/test_fallback.py
@@ -1,0 +1,91 @@
+# coding=utf-8
+# Copyright (C) 2020 NumS Development Team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import doctest
+import io
+import warnings
+from contextlib import redirect_stdout
+
+import numpy as np
+
+from nums.core import settings
+from nums.numpy.numpy_utils import update_doc_string
+
+warnings.filterwarnings("ignore", category=RuntimeWarning)
+
+
+# pylint: disable=import-outside-toplevel, possibly-unused-variable, eval-used, reimported
+
+def test_doctest_fallback(nps_app_inst):
+    import nums.numpy as nps
+    import numpy as np
+    assert nps_app_inst is not None
+
+    passed = []
+    failed = []
+    excepted = []
+
+    plot_funcs = {"kaiser", "bartlett", "hanning", "blackman", "histogram2d", "interp", "sinc"}
+
+    for func in settings.doctest_fallback:
+        nps_func = nps.__getattribute__(func)
+        nps_func.__doc__ = update_doc_string(np.__getattribute__(func).__doc__)
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            nps_func = nps.__getattribute__(func)
+
+            if func in plot_funcs:
+                # Skip plot functions and add them to the failed list
+                print("Failure")
+            else:
+                optionflags = doctest.NORMALIZE_WHITESPACE | doctest.FAIL_FAST
+                doctest.run_docstring_examples(nps_func, locals(), optionflags=optionflags)
+
+        if f.getvalue() == "":
+            passed.append(func)
+        else:
+            failed.append(func)
+
+    print("***DOCTESTS***")
+    print("PASSED:")
+    print(sorted(passed))
+    print("FAILED:")
+    print(sorted(failed))
+    print("EXCEPTED:")
+    print(sorted(excepted))
+
+
+def test_manual_cov(nps_app_inst):
+    assert nps_app_inst is not None
+
+    x = np.array([[0, 2], [1, 1], [2, 0]]).T
+    assert np.allclose(np.cov(x), np.array([[1., -1.], [-1., 1.]]))
+    x = [-2.1, -1, 4.3]
+    y = [3, 1.1, 0.12]
+    X = np.stack((x, y), axis=0)
+    assert np.allclose(np.cov(X), np.array([[11.71, -4.286], [-4.286, 2.144133]]))
+    assert np.allclose(np.cov(x, y), np.array([[11.71, -4.286], [-4.286, 2.144133]]))
+    assert np.allclose(np.cov(x), np.array(11.71))
+
+
+if __name__ == "__main__":
+    # pylint: disable=import-error
+    from nums.core import application_manager
+
+    settings.system_name = "serial"
+    nps_app_inst = application_manager.instance()
+    test_doctest_fallback(nps_app_inst)
+    test_manual_cov(nps_app_inst)

--- a/tests/numpy/test_misc.py
+++ b/tests/numpy/test_misc.py
@@ -207,6 +207,19 @@ def test_properties(nps_app_inst):
     assert A_copy is not A
 
 
+def test_arange(nps_app_inst):
+    import nums.numpy as nps
+    assert nps_app_inst is not None
+
+    start_indices = [3.1, 3, 3.1]
+    stop_indices = [5.1, 5.1, 5]
+
+    for start, stop in zip(start_indices, stop_indices):
+        a = nps.arange(start, stop).get()
+        b = np.arange(start, stop)
+        assert np.allclose(a, b)
+
+
 if __name__ == "__main__":
     from nums.core import application_manager
     from nums.core import settings
@@ -219,3 +232,4 @@ if __name__ == "__main__":
     # test_all_alltrue_any(nps_app_inst)
     # test_array_eq(nps_app_inst)
     test_properties(nps_app_inst)
+    test_arange(nps_app_inst)


### PR DESCRIPTION
- Moved `fallback` from `api_coverage.py` to `settings.py`
- Fixed small bugs in various methods that were found in failed doctests
- Updated deprecated uses of `np.bool`, `np.float`, and `np.int`
- Fixed `arange` not being able to handle float `start` and `stop` indices
- Fixed `linspace` normalizing incorrectly following the `arange` fix
- Removed the [NumPy Financial functions](https://www.w3resource.com/numpy/financial-functions/index.php) from the list of fallback methods
- Added a warning to fallback functions.