### PR TITLE
Add Binder integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,7 +131,6 @@ dmypy.json
 build
 .idea
 scratch
-notebooks
 data
 condaforge
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 [![PyPI version](https://badge.fury.io/py/nums.svg)](https://badge.fury.io/py/nums)
 [![Build Status](https://travis-ci.com/nums-project/nums.svg?branch=master)](https://travis-ci.com/nums-project/nums)
 [![codecov](https://codecov.io/gh/nums-project/nums/branch/master/graph/badge.svg)](https://codecov.io/gh/nums-project/nums)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/nums-project/nums-binder-env/master?urlpath=git-pull%3Frepo%3Dhttps%253A%252F%252Fgithub.com%252Fnums-project%252Fnums%26urlpath%3Dtree%252Fnums%252Fexamples%252Fnotebooks%26branch%3Dmaster)
+
+[//]: # (See this link to generate binder links https://jupyterhub.github.io/nbgitpuller/link?tab=binder)
 
 # What is NumS?
 
@@ -89,7 +92,6 @@ dataset = nums.read_csv("path/to/csv", has_header=True)
 ```
 
 ##  Logistic Regression
-
 In this example, we'll run logistic regression on a 
 bimodal Gaussian. We'll begin by importing the necessary modules.
 
@@ -135,6 +137,7 @@ tree-based optimizer to minimize memory and network load across distributed memo
 For tall-skinny design matrices, NumS will automatically perform data-parallel
 distributed training, a near optimal solution to our optimizer's objective.
 
+
 #### Evaluation
 
 We evaluate our dataset by computing the accuracy on a sampled test set.
@@ -150,6 +153,8 @@ print("test accuracy", (nps.sum(y_test == model.predict(X_test)) / X_test.shape[
 
 We perform the `get` operation to transmit 
 the computed accuracy from distributed memory to "driver" (the locally running process) memory.
+
+You can run this example in your browser [here](https://mybinder.org/v2/gh/nums-project/nums-binder-env/master?urlpath=git-pull%3Frepo%3Dhttps%253A%252F%252Fgithub.com%252Fnums-project%252Fnums%26urlpath%3Dtree%252Fnums%252Fexamples%252Fnotebooks%252Flogistic_regression.ipynb%26branch%3Dmaster).
 
 #### Training on HIGGS
 

--- a/examples/notebooks/logistic_regression.ipynb
+++ b/examples/notebooks/logistic_regression.ipynb
@@ -1,0 +1,63 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from nums import numpy as nps\n",
+    "from nums.models.glms import LogisticRegression"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Make dataset.\n",
+    "X1 = nps.random.randn(500, 1) + 5.0\n",
+    "y1 = nps.zeros(shape=(500,), dtype=bool)\n",
+    "X2 = nps.random.randn(500, 1) + 10.0\n",
+    "y2 = nps.ones(shape=(500,), dtype=bool)\n",
+    "X = nps.concatenate([X1, X2], axis=0)\n",
+    "y = nps.concatenate([y1, y2], axis=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Train Logistic Regression Model.\n",
+    "model = LogisticRegression(solver=\"newton-cg\", tol=1e-8, max_iter=1)\n",
+    "model.fit(X, y)\n",
+    "y_pred = model.predict(X)\n",
+    "print(\"accuracy\", (nps.sum(y == y_pred) / X.shape[0]).get())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
* Add Binder badge in Readme that links to the example directory (that ideally contains example notebooks)
* Add a sample Binder link for Logistic Regression example in the readme that directly opens the notebook 

(Binder searches for build configuration files in the repo, which is setup.py in our case, and builds a docker image using that(using [repo2docker](https://repo2docker.readthedocs.io/en/latest/)). It builds a new docker image each time there is any chage in the repo. That adds a lot of time for the initial binder launch. A workaround is to create a separate repo([nums-binder-env](https://github.com/nums-project/nums-binder-env)) with the environment configuration files that will not be updated frequently. and then link the content repo(nums repo example [folder](https://github.com/nums-project/nums/tree/master/examples)))