### PR TITLE
Add support for Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
     env:
       OS: 'ubuntu'
       PYTHON: ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ print("accuracy", (nps.sum(y == y_pred) / X.shape[0]).get())
 ```
 
 # Installation
-NumS releases are tested on Linux-based systems running Python 3.6, 3.7, and 3.8.
+NumS releases are tested on Linux-based systems running Python 3.7, 3.8, and 3.9.
 
 NumS runs on Windows, but not all features are tested. We recommend using Anaconda on Windows. Download and install Anaconda for Windows [here](https://docs.anaconda.com/anaconda/install/windows/). Make sure to add Anaconda to your PATH environment variable during installation.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ classifiers =
 
 [options]
 packages = find:
-python_requires = >=3.6,<3.9
+python_requires = >=3.6,<3.10
 install_requires =
     numpy>1.18.0,<=1.20.0
     ray[default]>=1.0.0,<=1.6.0


### PR DESCRIPTION
Fixes #162 

For some reason Python 3.9 wasn't working previously, but it does now. I think it has something to do with the fact we bumped the Ray version.