### PR TITLE
Check formatting on all Python files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,5 +35,4 @@ jobs:
           pip3 install .[testing]
       - name: Run black
         run: |
-          black --check nums
-          black --check tests
+          black --check .


### PR DESCRIPTION
The lint workflow previously checked the `nums` and `tests` folder. However, there are other Python files that need to be formatted, like `setup.py` and files in the `autoscaler` folder. I've updated the workflow to check all Python files in the repo for formatting.

**Merge #169 before merging this PR.**