### PR TITLE
Fixes MPI tests to actually execute on more than one rank.

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ The following dependencies need to be installed (on Ubuntu or related Linux mach
 
 ```sh
 sudo apt update
-sudo apt-get mpich
+sudo apt-get install mpich
 pip install mpi4py
 ```
 

--- a/nums/core/backends/mpi.py
+++ b/nums/core/backends/mpi.py
@@ -185,12 +185,12 @@ class MPIBackend(Backend):
             # If the object is not local then execute a receive.
             sender_rank = obj.rank
             # TODO: Try Isend and Irecv and have a switch for sync and async.
-            arg_value = self.comm.recv(sender_rank)
+            arg_value = self.comm.recv(source=sender_rank)
             return arg_value
         elif isinstance(obj, MPILocalObj):
             # The obj is stored on this rank, so send it to the device on which the op will be
             # executed.
-            self.comm.send(obj.value, device_rank)
+            self.comm.send(obj.value, dest=device_rank)
             return obj
         else:
             # The obj is remote and this is not the device on which we want to invoke the op.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,24 +119,30 @@ def app_inst_all(request):
 def get_app(backend_name, device_grid_name="cyclic"):
     if backend_name == "serial":
         backend: Backend = SerialBackend()
+        backend.init()
+        cluster_shape = (1, 1)
     elif backend_name == "ray":
         assert not ray.is_initialized()
         backend: Backend = RayBackend(
             use_head=True, num_cpus=backend_utils.get_num_cores()
         )
+        backend.init()
+        cluster_shape = (1, 1)
     elif backend_name == "dask":
         from nums.experimental.nums_dask.dask_backend import DaskBackend
 
         backend: Backend = DaskBackend(
             num_cpus=backend_utils.get_num_cores(), num_nodes=1
         )
+        backend.init()
+        cluster_shape = (1, 1)
     elif backend_name == "mpi":
         backend: Backend = MPIBackend()
+        backend.init()
+        cluster_shape = (len(backend.devices()), 1)
     else:
         raise Exception("Unexpected backend name %s" % backend_name)
-    backend.init()
 
-    cluster_shape = (1, 1)
     if device_grid_name == "cyclic":
         device_grid: DeviceGrid = CyclicDeviceGrid(
             cluster_shape, "cpu", backend.devices()


### PR DESCRIPTION
@vinamrabenara tests configured with mpi backend were not actually configuring nums to use more than 1 rank, even though MPI may be launched with more than 1 rank.