### PR TITLE
Alias `bitwise_not` with `invert`

### DIFF
--- a/docs/source/numpy.rst
+++ b/docs/source/numpy.rst
@@ -79,7 +79,6 @@ NumS Supported API
    arcsinh
    arctan
    arctanh
-   bitwise_not
    cbrt
    ceil
    conj

--- a/docs/source/reference/numpy.rst
+++ b/docs/source/reference/numpy.rst
@@ -79,7 +79,6 @@ NumS Supported API
    arcsinh
    arctan
    arctanh
-   bitwise_not
    cbrt
    ceil
    conj

--- a/nums/numpy/api/generated.py
+++ b/nums/numpy/api/generated.py
@@ -699,6 +699,9 @@ def bitwise_not(
     )
 
 
+invert = bitwise_not
+
+
 def cbrt(x: BlockArray, out: BlockArray = None, where=True, **kwargs) -> BlockArray:
     """Return the cube-root of an array, element-wise.
 


### PR DESCRIPTION
`bitwise_not` is not documented in the NumPy documentation (although, it is implemented).

For parity with NumPy, this PR:
1. Aliases `invert` with `bitwise_not`
2. Removes `bitwise_not` from the NumS documentation (`invert` remains in the NumS documentation).